### PR TITLE
Change to AWS SAM Published application for easy install (supports all regions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,16 @@ without the comma character, or a full CloudFormation Stack ARN.
 
 ## Deployment
 
-### Deploy using Quick-create link
+### Deploy from the AWS Lambda Console
 
-For your convenience, the latest prebuilt version of this application can be launched in your AWS account using the following
-AWS CloudFormation quick-create link. Click the following button to start:
+For your convenience, the latest prebuilt version of this application can be launched in your AWS account by visiting from the AWS Serverless Application Repository.
 
-[![Launch Stack](docs/images/launch-stack.svg)](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https%3A%2F%2Fcloudconformity.s3-us-west-2.amazonaws.com%2Fcloudformation-drift-detection%2Ftemplate.yaml&stackName=cloudformation-drift-detection)
+1. Visit [the app's page on the AWS Lambda Console](https://console.aws.amazon.com/lambda/home?#/create/app?applicationId=arn:aws:serverlessrepo:us-west-2:717210094962:applications/cloudformation-drift-detection). 
+2. Fill in the required parameters.
+3. Select the `I acknowledge that this app creates custom IAM roles.` checkbox.
+4. Select `Deploy`.
 
-You can use [CloudFormation StackSets](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack-set.html)
-to deploy this application to multiple accounts. You can review [the CloudFormation template for this application](https://cloudconformity.s3-us-west-2.amazonaws.com/cloudformation-drift-detection/template.yaml) before using it.
-
-### Deploy using AWS SAM
+### Deploy using AWS SAM CLI
 
 The AWS SAM CLI is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
 

--- a/template.yml
+++ b/template.yml
@@ -1,9 +1,28 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: >-
-  Tools to regularly trigger drift detection on AWS CloudFormation Stacks
-
 Transform:
   - AWS::Serverless-2016-10-31
+
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: tools-cloudformation-drift-detection
+    Description: >-
+      Tools to regularly trigger drift detection on AWS CloudFormation Stacks
+    Author: Trend Micro
+    SpdxLicenseId: MIT
+    LicenseUrl: LICENSE
+    ReadmeUrl: README.md
+    Labels:
+      [
+        trendmicro,
+        cloudone,
+        cloudconformity,
+        conformity,
+        cloudformation,
+        securityautomation,
+      ]
+    HomePageUrl: https://github.com/cloudconformity/tools-cloudformation-drift-detection
+    SemanticVersion: 1.0.0
+    SourceCodeUrl: https://github.com/cloudconformity/tools-cloudformation-drift-detection
 
 Parameters:
   Regions:


### PR DESCRIPTION
### Issue Link:

N/A - Currently the published cloudformation template cannot be deployed outside of us-west-2 due to cloudformation requiring code packages to be on same region as where function is deployed.

### What does it do?

Changes the quick link to use a published SAM application. (This isn't actually published yet, you will need follow the steps in: https://docs.aws.amazon.com/serverlessrepo/latest/devguide/serverlessrepo-how-to-publish.html

#### Checklist (if applicable)

- [X] README update

---

#### Notes to reviewers

Application is not actually published, assumed AWS account ID for publishing application would be the same as production conformity accountid.
See screenshot of what an example publish application looks like or reach out to me to run through the steps of publishing :)

End result will look something like this
![aws sam example](https://user-images.githubusercontent.com/25472582/122012181-3c2f8080-ce00-11eb-8aec-dd3469049ffa.PNG)


