### PR TITLE
Cloudwatch Loggroup with configurable retention

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -43,7 +43,29 @@ Parameters:
     Description: >-
       Comma-separated list of CloudFormation Stack ARNs to be excluded by the system. Each item can be a regular expression
       without the comma character or a full CloudFormation Stack ARN.
-
+  LogRetentionDays:
+    Type: String
+    Default: "1"
+    Description: >-
+      Retention in days to keep the Lambda log files in Cloudwatch Logs
+    AllowedValues:
+      - 1
+      - 3
+      - 5
+      - 7
+      - 14
+      - 30
+      - 60
+      - 90
+      - 120
+      - 150
+      - 180
+      - 365
+      - 400
+      - 545
+      - 731
+      - 1827
+      - 3653
 Resources:
   TriggerCloudFormationDriftDetection:
     Type: AWS::Serverless::Function
@@ -73,3 +95,8 @@ Resources:
       Timeout: 300
       Tags:
         Name: triggerCloudFormationDriftDetection
+  LambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ["", ["/aws/lambda/", !Ref TriggerCloudFormationDriftDetection]]
+      RetentionInDays: !Ref LogRetentionDays


### PR DESCRIPTION
### Issue Link:

none

### What does it do?

Adds a Cloudwatch Log group to the template in stead of relying on the auto-created one at the first run of the lambda function. This allows a configurable retention for the loggroup, and also a cleanup of the logggroup when the deployed stack gets deleted again
