### PR TITLE
Add maintenance warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # CloudFormation drift detection
 
+> [!WARNING]  
+> This repository is no longer maintained.
+>
+> Checkout AWS blog post: [Implementing an Alarm to Automatically Detect Drift in AWS CloudFormation Stacks](https://aws.amazon.com/blogs/mt/implementing-an-alarm-to-automatically-detect-drift-in-aws-cloudformation-stacks/) for a better way to achieve this using **AWS Config** and **Amazon EventBridge**.
+
+
 - [CloudFormation drift detection](#cloudformation-drift-detection)
   - [Introduction](#introduction)
   - [Purpose](#purpose)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]  
 > This repository is no longer maintained.
 >
-> Checkout AWS blog post: [Implementing an Alarm to Automatically Detect Drift in AWS CloudFormation Stacks](https://aws.amazon.com/blogs/mt/implementing-an-alarm-to-automatically-detect-drift-in-aws-cloudformation-stacks/) for a better way to achieve this using **AWS Config** and **Amazon EventBridge**.
+> Check out AWS blog post: [Implementing an Alarm to Automatically Detect Drift in AWS CloudFormation Stacks](https://aws.amazon.com/blogs/mt/implementing-an-alarm-to-automatically-detect-drift-in-aws-cloudformation-stacks/) for a better way to achieve this using **AWS Config** and **Amazon EventBridge**.
 
 
 - [CloudFormation drift detection](#cloudformation-drift-detection)


### PR DESCRIPTION
This repository is out of date and is no longer the best way to automatically perform CloudFormation Stack drift detection.

This commit adds a warning to users to warn against using this repository.

![image](https://github.com/user-attachments/assets/70798722-0ed9-47b7-9a13-b9c1b00dbeae)
